### PR TITLE
docs: registrar estabilización e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ## [Unreleased]
 
+### Changed - 2025-10-04
+
+- **E2E Pipeline Estabilizado**:
+  - Tests de reservas y CleanScore ahora simulan respuestas vía `window.fetch` para evitar dependencias externas.
+  - El reporte de seguridad ya no descarga artefactos ni comenta en PRs, eliminando errores 403 y reintentos fallidos en CI.
+
 ### Added - 2025-10-02
 
 #### Production-Ready Security & Performance

--- a/docs/for-developers/testing.md
+++ b/docs/for-developers/testing.md
@@ -326,6 +326,12 @@ pnpm playwright test home.spec.ts
 pnpm playwright test --debug
 ```
 
+### Mocks de red y datos deterministas
+
+- Los specs `apps/web/e2e/booking-flow.spec.ts` y `apps/web/e2e/cleanscore-dashboard.spec.ts` reemplazan `window.fetch` al inicio de cada test para responder con fixtures controladas.
+- Las capturas de payload (`bookingCalls`, `patchCalls`) se exponen mediante `page.exposeBinding`, permitiendo aserciones sin depender de servicios externos.
+- Este enfoque garantiza que los flujos críticos funcionen igual en local y en CI aun sin backend disponible.
+
 ### Estructura de un Test E2E
 
 [apps/web/e2e/home.spec.ts](https://github.com/albertodimas/brisa-cubana-clean-intelligence/blob/main/apps/web/e2e/home.spec.ts):
@@ -482,6 +488,12 @@ test("should create booking", async ({ page }) => {
   await expect(page).toHaveURL(/\/dashboard\/bookings\/[a-z0-9-]+/);
 });
 ```
+
+### Evidencias y reportes
+
+- `pnpm exec playwright test` genera un reporte HTML navegable en `playwright-report/index.html`.
+- Los videos y capturas de fallos se guardan en `test-results/**/video.webm` y `test-results/**/test-failed-*.png`.
+- En CI, el job **E2E** publica el reporte HTML como artefacto y el job **Security Summary** adjunta `security-report.md` con el estado de los escaneos.
 
 ---
 


### PR DESCRIPTION
## Resumen
- documentar mocks deterministas en los flujos E2E
- registrar en el changelog la estabilización del pipeline

## Checklist
- [x] Tests locales relevantes
- [x] Documentación actualizada