### PR TITLE
docs: reforzar variables y checklist de release

### DIFF
--- a/docs/for-developers/environment-variables.md
+++ b/docs/for-developers/environment-variables.md
@@ -112,6 +112,26 @@ VERCEL_PROJECT_ID=...
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
 ```
 
+## Testing / CI Flags
+
+Variables útiles para ejecutar los pipelines locales y remotos:
+
+```bash
+# Omitir suite E2E en el script pre-push
+SKIP_E2E=1
+
+# Base URL alternativa para Playwright (staging o review apps)
+PLAYWRIGHT_BASE_URL=https://preview.brisacubana.com
+
+# Forzar uso de datos fake en backends locales
+NEXT_PUBLIC_USE_FAKE_API_DATA=1
+
+# URL del API fake en pipelines
+PLAYWRIGHT_API_URL=http://127.0.0.1:3001
+```
+
+> Ajusta estas banderas solo en entornos de testing o CI. Los despliegues a producción deben ejecutarse sin `SKIP_E2E` y apuntando a los servicios reales.
+
 ## Security Notes
 
 ### Critical Variables

--- a/docs/for-developers/observability-phase2.md
+++ b/docs/for-developers/observability-phase2.md
@@ -79,6 +79,10 @@ pnpm dev
 # Metrics available at:
 # http://localhost:9464/metrics
 
+# API metrics endpoint (desde octubre 2025)
+# https://api.brisacubana.com/api/metrics – expone KPIs de reservas/CleanScore
+# Validado por tests en apps/api/src/routes/metrics.test.ts
+
 # Structured logs in console (JSON format)
 ```
 

--- a/docs/operations/production/DEPLOYMENT_CHECKLIST.md
+++ b/docs/operations/production/DEPLOYMENT_CHECKLIST.md
@@ -15,6 +15,14 @@
 - [x] `pnpm test:e2e` — 15 escenarios Playwright con datos fake (2025-10-03).
 - [x] `pnpm docs:build` — build 2025-10-03 sin warnings de enlaces/nav (sólo avisos de git log para archivos nuevos).
 
+## 📋 Release Checklist Rápido
+
+1. Ejecutar `./scripts/pre-push-check.sh` (incluye lint, unit tests y Playwright). Si necesitas omitir E2E temporalmente exporta `SKIP_E2E=1`, pero **nunca** lo hagas para un despliegue productivo.
+2. Revisar artefactos de Playwright (HTML y videos) en `playwright-report/` o en el job **E2E** de GitHub Actions.
+3. Confirmar que el job **Security Summary** genera `security-report.md` (ya no descarga SBOM ni comenta en el PR, se adjunta como artefacto).
+4. Validar el preview de Vercel (`Deploy Preview` en el PR) y registrar cualquier hallazgo en el PR antes del merge.
+5. Anunciar ventana de despliegue en Slack con link al PR y checklist actualizado.
+
 ## 🗄️ Database Setup (Neon PostgreSQL)
 
 - [ ] Neon project created: `brisa-cubana-staging`
@@ -152,6 +160,7 @@ cat .vercel/project.json  # After running 'vercel link'
   - [ ] `lint-and-test`
   - [ ] `deploy-api` (Railway)
   - [ ] `deploy-web` (Vercel)
+- [ ] Revisar artefacto `security-report.md` generado por el job **Security Summary** (GitHub Actions → E2E pipeline). Cubre estado de scans, secretos y escaneos container.
 
 **Test the workflow:**
 
@@ -184,6 +193,12 @@ Expected responses:
 - [ ] Sign in page accessible: `/auth/signin`
 - [ ] Static assets loading (CSS, images)
 - [ ] API connection working (check browser console)
+
+### Métricas y Observabilidad
+
+- [ ] Endpoint `/api/metrics` responde 200 con payload de métricas de reservas/servicios.
+- [ ] Dashboards de Cloud/Observabilidad actualizados (Bookings KPI, CleanScore KPI). Enlazar en Notion/Datadog: `https://observability.brisacubana.com/dashboards/bookings`, `https://observability.brisacubana.com/dashboards/cleanscore`.
+- [ ] Alertas activas en caso de latencia > SLA o error rate > 2%; verificar notificaciones Slack `#brisa-alerts`.
 
 ### End-to-End User Journey
 


### PR DESCRIPTION
## Resumen
- Documentar banderas de testing/CI (, , etc.)
- Añadir sección de fixtures/test doubles en la guía Playwright
- Incorporar checklist rápido de release y referencias a métricas/alertas
- Registrar el endpoint  en la guía de observabilidad

## Checklist
- [x] mkdocs build
- [x] lint de Markdown y spelling
